### PR TITLE
jx-gke-tutorial to 0.0.5

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,4 +9,4 @@ dependencies:
   version: 2.3.89
 - name: jx-gke-tutorial
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.4
+  version: 0.0.5


### PR DESCRIPTION
Promote jx-gke-tutorial to version 0.0.5